### PR TITLE
feat: forward GCS parameter as structured google_consent_mode object (SER-792)

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -253,6 +253,9 @@ addEventCallback((containerId, eventData) => {
     user_agent_hashed: userAgent ? sha256Sync(userAgent, { outputEncoding: 'base64' }) : null,
     page_hostname: getEventData('page_hostname'),
     consent_settings: googleConsent,
+    google_consent_mode: {
+      gcs: googleConsent || null
+    },
     container_version: containerVersion.version,
     has_richsstsse: hasRichSstSse,
     tag: eventData.tags.filter(tag => tag.exclude !== 'true').map(tag => ({


### PR DESCRIPTION
Add google_consent_mode.gcs to the monitoring payload alongside the existing consent_settings field for backward compatibility. The new field wraps the raw GCS value in a structured object for downstream ECM V2 processing.